### PR TITLE
Reduce cpu usage of weas component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "plotly.js": "^2.33.0",
         "react-plotly.js": "^2.6.0",
         "sass": "^1.77.4",
-        "weas": "^0.1.11"
+        "weas": "^0.1.26"
       },
       "devDependencies": {
         "@types/node": "^22.8.4",
@@ -5022,10 +5022,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.160.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
-      "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
-      "license": "MIT"
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w=="
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -5298,13 +5297,12 @@
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
     },
     "node_modules/weas": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/weas/-/weas-0.1.11.tgz",
-      "integrity": "sha512-iRUb84RXbl7toQjRBVWBseK1ZDBQPtUdj+maw+VLzllHxWPGz2EbaopDSHaijeetWAdoR+5V+oSJLqKey2mlNQ==",
-      "license": "MIT",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/weas/-/weas-0.1.26.tgz",
+      "integrity": "sha512-chTisQepdW7cyQoV/jCBhNcBhPUz53r0a2iZvS2PbqJk6DObkDtfieFfemrxHdSSshHeywHdWzKvUyzXUmSdzg==",
       "dependencies": {
         "dat.gui": "^0.7.9",
-        "three": "^0.160.1"
+        "three": "^0.169.0"
       }
     },
     "node_modules/webgl-context": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "plotly.js": "^2.33.0",
         "react-plotly.js": "^2.6.0",
         "sass": "^1.77.4",
-        "weas": "^0.1.26"
+        "weas": "^0.1.27"
       },
       "devDependencies": {
         "@types/node": "^22.8.4",
@@ -5297,9 +5297,9 @@
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
     },
     "node_modules/weas": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/weas/-/weas-0.1.26.tgz",
-      "integrity": "sha512-chTisQepdW7cyQoV/jCBhNcBhPUz53r0a2iZvS2PbqJk6DObkDtfieFfemrxHdSSshHeywHdWzKvUyzXUmSdzg==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/weas/-/weas-0.1.27.tgz",
+      "integrity": "sha512-ILcBbtusWdO1jkRmsLWzKjzKikrnlL9eqfMCEwww/pLnnFao28vDh50lqSZqy0LjRgc9RPrcDVzrWDLGbrA62Q==",
       "dependencies": {
         "dat.gui": "^0.7.9",
         "three": "^0.169.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "plotly.js": "^2.33.0",
     "react-plotly.js": "^2.6.0",
     "sass": "^1.77.4",
-    "weas": "^0.1.26"
+    "weas": "^0.1.27"
   },
   "peerDependencies": {
     "bootstrap": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "plotly.js": "^2.33.0",
     "react-plotly.js": "^2.6.0",
     "sass": "^1.77.4",
-    "weas": "^0.1.11"
+    "weas": "^0.1.26"
   },
   "peerDependencies": {
     "bootstrap": "^5.3.3",

--- a/src/components/CellView.tsx
+++ b/src/components/CellView.tsx
@@ -9,14 +9,15 @@ import { VisualizerProps } from "./types";
 import "./CellView.scss";
 
 const defaultGuiConfig = {
-  enabled: false,
   components: {
+    enabled: false,
     atomsControl: true,
     colorControl: true,
     cameraControls: false,
     buttons: true,
   },
   buttons: {
+    enabled: true,
     fullscreen: true,
     undo: false,
     redo: false,
@@ -106,12 +107,6 @@ const CellView = ({
     }
     weas.avr.frameDuration = 4 / speed;
     weas.avr.tjs.updateCameraAndControls({ direction: cameraDirection });
-    weas.avr.VFManager.addSetting({
-      origins: "positions",
-      vectors: "movement",
-      color: "red",
-      radius: 0.1,
-    });
     weas.avr.showCell = showCell;
     weas.avr.VFManager.show = showVectors;
     weas.avr.drawModels();

--- a/src/components/CellView.tsx
+++ b/src/components/CellView.tsx
@@ -91,7 +91,7 @@ const CellView = ({
       atoms: atoms,
       eigenvectors: props.vectors[q][e],
       amplitude: amplitude * 5,
-      nframes: 20 / speed,
+      nframes: 10 / speed,
       kpoint: props.qpoints[q],
       repeat: [nx, ny, nz],
     });
@@ -105,7 +105,7 @@ const CellView = ({
       // pause the animation at start as it can be quite demanding
       weas.avr.pause();
     }
-    weas.avr.frameDuration = 4 / speed;
+    weas.avr.frameDuration = 15 / speed;
     weas.avr.tjs.updateCameraAndControls({ direction: cameraDirection });
     weas.avr.showCell = showCell;
     weas.avr.VFManager.show = showVectors;

--- a/src/components/CellView.tsx
+++ b/src/components/CellView.tsx
@@ -9,7 +9,7 @@ import { VisualizerProps } from "./types";
 import "./CellView.scss";
 
 const defaultGuiConfig = {
-  components: {
+  controls: {
     enabled: false,
     atomsControl: true,
     colorControl: true,
@@ -17,7 +17,7 @@ const defaultGuiConfig = {
     buttons: true,
   },
   buttons: {
-    enabled: true,
+    enabled: false,
     fullscreen: true,
     undo: false,
     redo: false,


### PR DESCRIPTION
This PR reduces the CPU consumption by the weas component in two parts:

- bump was to the latest 0.1.27, which avoids re-drawing cells in the animation. Also, using the new syntax of weas.
- increase time duration and decrease the number of frames. The animation is still in a reasonable resolution. Note, too many frames and short frame duration lead to too many rendering, thus high CPU consumption.


In my local test, it reduce the CPU a lot (one CPU from 60% to 30%). Hi @eimrek , please try and test.