### PR TITLE
Fix band zoom reset upon hovering

### DIFF
--- a/src/components/BandsView.tsx
+++ b/src/components/BandsView.tsx
@@ -1,10 +1,114 @@
-import { memo, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { Card } from "react-bootstrap";
 import Plot from "react-plotly.js";
 
 import { PlotDatum, PlotMouseEvent } from "plotly.js";
 
 import { HighSymPoint } from "./types";
+
+const getLayout = (
+  highSymPoints: HighSymPoint[],
+  distances: number[],
+  eigenvalues: number[][]
+) => ({
+  showlegend: false,
+  hovermode: "closest",
+  xaxis: {
+    linewidth: 0,
+    linecolor: "transparent",
+    tickvals: highSymPoints.map(([index]) => distances[index]),
+    ticktext: highSymPoints.map(([, label]) => label),
+    range: [Math.min(...distances.flat()), Math.max(...distances.flat())],
+  },
+  yaxis: {
+    title: "Frequency (cm-1)",
+    linewidth: 0,
+    linecolor: "transparent",
+    ticklen: 5,
+    range: [Math.min(...eigenvalues.flat()), Math.max(...eigenvalues.flat())],
+  },
+  // vertical lines at high-symmetry points
+  shapes: highSymPoints.map(([index]) => ({
+    type: "line",
+    yref: "paper",
+    x0: distances[index],
+    y0: 0,
+    x1: distances[index],
+    y1: 1,
+    line: {
+      width: 0.5,
+    },
+  })),
+  dragmode: "zoom",
+  autosize: true,
+  margin: {
+    l: 55,
+    r: 10,
+    b: 25,
+    t: 40,
+  },
+});
+
+const getPlotData = (
+  bands: number[][],
+  distances: number[],
+  hoveredPoint: PlotDatum | null,
+  selectedPoint: PlotDatum | null
+) => {
+  return bands.map((band, index) => ({
+    x: distances,
+    y: band,
+    mode: "lines+markers",
+    hoverinfo: "none",
+    line: {
+      color: "#1f77b4",
+      width: hoveredPoint?.curveNumber === index ? 4 : 2,
+    },
+    marker: {
+      // size should be 2 if hovered on, 4 if selected, 0 otherwise; hover/selection is determined by both x and y, no border
+      size: band.map((_, index) =>
+        selectedPoint?.x === distances[index] &&
+        selectedPoint?.y === band[index]
+          ? 10
+          : hoveredPoint?.x === distances[index] &&
+            hoveredPoint?.y === band[index]
+          ? 14
+          : 0
+      ),
+      color: band.map((_, index) =>
+        selectedPoint?.x === distances[index] &&
+        selectedPoint?.y === band[index]
+          ? "red"
+          : hoveredPoint?.x === distances[index] &&
+            hoveredPoint?.y === band[index]
+          ? "blue"
+          : "#1f77b4"
+      ),
+      // add opaque border around marker of width 1 (black) if selected, width 10 (lightblue) if hovered on
+      line: {
+        width: band.map((_, index) =>
+          selectedPoint?.x === distances[index] &&
+          selectedPoint?.y === band[index]
+            ? 1
+            : hoveredPoint?.x === distances[index] &&
+              hoveredPoint?.y === band[index]
+            ? 8
+            : 0
+        ),
+        color: band.map((_, index) =>
+          selectedPoint?.x === distances[index] &&
+          selectedPoint?.y === band[index]
+            ? "black"
+            : hoveredPoint?.x === distances[index] &&
+              hoveredPoint?.y === band[index]
+            ? "lightblue"
+            : "transparent"
+        ),
+      },
+      opacity: 1,
+    },
+  }));
+};
 
 const BandsView = ({
   distances,
@@ -24,6 +128,25 @@ const BandsView = ({
     eigenvalues.map((row) => row[colIndex])
   );
 
+  const [plotState, setPlotState] = useState({
+    data: getPlotData(bands, distances, hoveredPoint, selectedPoint),
+    layout: getLayout(highSymPoints, distances, eigenvalues),
+    frames: [],
+    config: {
+      scrollZoom: false,
+      displayModeBar: true,
+      displaylogo: false,
+      modeBarButtons: [["toImage", "resetScale2d"]],
+    },
+  });
+
+  useEffect(() => {
+    setPlotState((oldState) => ({
+      ...oldState,
+      data: getPlotData(bands, distances, hoveredPoint, selectedPoint),
+    }));
+  }, [hoveredPoint, selectedPoint]);
+
   const handleSelection = (event: PlotMouseEvent) => {
     updateMode(event);
     setSelectedPoint(event.points[0]);
@@ -34,115 +157,15 @@ const BandsView = ({
       <Card.Header>Phonon band structure (select phonon)</Card.Header>
       <Card.Body>
         <Plot
-          data={bands.map((band, index) => ({
-            x: distances,
-            y: band,
-            mode: "lines+markers",
-            hoverinfo: "none",
-            line: {
-              color: "#1f77b4",
-              width: hoveredPoint?.curveNumber === index ? 4 : 2,
-            },
-            marker: {
-              // size should be 2 if hovered on, 4 if selected, 0 otherwise; hover/selection is determined by both x and y, no border
-              size: band.map((_, index) =>
-                selectedPoint?.x === distances[index] &&
-                selectedPoint?.y === band[index]
-                  ? 10
-                  : hoveredPoint?.x === distances[index] &&
-                    hoveredPoint?.y === band[index]
-                  ? 14
-                  : 0
-              ),
-              color: band.map((_, index) =>
-                selectedPoint?.x === distances[index] &&
-                selectedPoint?.y === band[index]
-                  ? "red"
-                  : hoveredPoint?.x === distances[index] &&
-                    hoveredPoint?.y === band[index]
-                  ? "blue"
-                  : "#1f77b4"
-              ),
-              // add opaque border around marker of width 1 (black) if selected, width 10 (lightblue) if hovered on
-              line: {
-                width: band.map((_, index) =>
-                  selectedPoint?.x === distances[index] &&
-                  selectedPoint?.y === band[index]
-                    ? 1
-                    : hoveredPoint?.x === distances[index] &&
-                      hoveredPoint?.y === band[index]
-                    ? 8
-                    : 0
-                ),
-                color: band.map((_, index) =>
-                  selectedPoint?.x === distances[index] &&
-                  selectedPoint?.y === band[index]
-                    ? "black"
-                    : hoveredPoint?.x === distances[index] &&
-                      hoveredPoint?.y === band[index]
-                    ? "lightblue"
-                    : "transparent"
-                ),
-              },
-              opacity: 1,
-            },
-          }))}
-          layout={{
-            showlegend: false,
-            hovermode: "closest",
-            xaxis: {
-              linewidth: 0,
-              linecolor: "transparent",
-              tickvals: highSymPoints.map(([index]) => distances[index]),
-              ticktext: highSymPoints.map(([, label]) => label),
-              range: [
-                Math.min(...distances.flat()),
-                Math.max(...distances.flat()),
-              ],
-            },
-            yaxis: {
-              title: "Frequency (cm-1)",
-              linewidth: 0,
-              linecolor: "transparent",
-              ticklen: 5,
-              range: [
-                Math.min(...eigenvalues.flat()),
-                Math.max(...eigenvalues.flat()),
-              ],
-            },
-            // vertical lines at high-symmetry points
-            shapes: highSymPoints.map(([index]) => ({
-              type: "line",
-              yref: "paper",
-              x0: distances[index],
-              y0: 0,
-              x1: distances[index],
-              y1: 1,
-              line: {
-                width: 0.5,
-              },
-            })),
-            dragmode: "zoom",
-            autosize: true,
-            margin: {
-              l: 55,
-              r: 10,
-              b: 25,
-              t: 40,
-            },
-          }}
+          data={plotState.data}
+          layout={plotState.layout}
+          config={plotState.config}
           onClick={handleSelection}
           onHover={(event) => {
             setHoveredPoint(event.points[0]);
           }}
           onUnhover={() => {
             setHoveredPoint(null);
-          }}
-          config={{
-            scrollZoom: false,
-            displayModeBar: true,
-            displaylogo: false,
-            modeBarButtons: [["toImage", "resetScale2d"]],
           }}
           useResizeHandler={true}
           style={{

--- a/src/components/BandsView.tsx
+++ b/src/components/BandsView.tsx
@@ -6,67 +6,6 @@ import { PlotDatum, PlotMouseEvent } from "plotly.js";
 
 import { HighSymPoint } from "./types";
 
-const getPlotData = (
-  bands: number[][],
-  distances: number[],
-  hoveredPoint: PlotDatum | null,
-  selectedPoint: PlotDatum | null
-) => {
-  return bands.map((band, index) => ({
-    x: distances,
-    y: band,
-    mode: "lines+markers",
-    hoverinfo: "none",
-    line: {
-      color: "#1f77b4",
-      width: hoveredPoint?.curveNumber === index ? 4 : 2,
-    },
-    marker: {
-      // size should be 2 if hovered on, 4 if selected, 0 otherwise; hover/selection is determined by both x and y, no border
-      size: band.map((_, index) =>
-        selectedPoint?.x === distances[index] &&
-        selectedPoint?.y === band[index]
-          ? 10
-          : hoveredPoint?.x === distances[index] &&
-            hoveredPoint?.y === band[index]
-          ? 14
-          : 0
-      ),
-      color: band.map((_, index) =>
-        selectedPoint?.x === distances[index] &&
-        selectedPoint?.y === band[index]
-          ? "red"
-          : hoveredPoint?.x === distances[index] &&
-            hoveredPoint?.y === band[index]
-          ? "blue"
-          : "#1f77b4"
-      ),
-      // add opaque border around marker of width 1 (black) if selected, width 10 (lightblue) if hovered on
-      line: {
-        width: band.map((_, index) =>
-          selectedPoint?.x === distances[index] &&
-          selectedPoint?.y === band[index]
-            ? 1
-            : hoveredPoint?.x === distances[index] &&
-              hoveredPoint?.y === band[index]
-            ? 8
-            : 0
-        ),
-        color: band.map((_, index) =>
-          selectedPoint?.x === distances[index] &&
-          selectedPoint?.y === band[index]
-            ? "black"
-            : hoveredPoint?.x === distances[index] &&
-              hoveredPoint?.y === band[index]
-            ? "lightblue"
-            : "transparent"
-        ),
-      },
-      opacity: 1,
-    },
-  }));
-};
-
 const BandsView = ({
   distances,
   highSymPoints,
@@ -133,6 +72,67 @@ const BandsView = ({
       </Card.Body>
     </Card>
   );
+};
+
+const getPlotData = (
+  bands: number[][],
+  distances: number[],
+  hoveredPoint: PlotDatum | null,
+  selectedPoint: PlotDatum | null
+) => {
+  return bands.map((band, index) => ({
+    x: distances,
+    y: band,
+    mode: "lines+markers",
+    hoverinfo: "none",
+    line: {
+      color: "#1f77b4",
+      width: hoveredPoint?.curveNumber === index ? 4 : 2,
+    },
+    marker: {
+      // size should be 2 if hovered on, 4 if selected, 0 otherwise; hover/selection is determined by both x and y, no border
+      size: band.map((_, index) =>
+        selectedPoint?.x === distances[index] &&
+        selectedPoint?.y === band[index]
+          ? 10
+          : hoveredPoint?.x === distances[index] &&
+            hoveredPoint?.y === band[index]
+          ? 14
+          : 0
+      ),
+      color: band.map((_, index) =>
+        selectedPoint?.x === distances[index] &&
+        selectedPoint?.y === band[index]
+          ? "red"
+          : hoveredPoint?.x === distances[index] &&
+            hoveredPoint?.y === band[index]
+          ? "blue"
+          : "#1f77b4"
+      ),
+      // add opaque border around marker of width 1 (black) if selected, width 10 (lightblue) if hovered on
+      line: {
+        width: band.map((_, index) =>
+          selectedPoint?.x === distances[index] &&
+          selectedPoint?.y === band[index]
+            ? 1
+            : hoveredPoint?.x === distances[index] &&
+              hoveredPoint?.y === band[index]
+            ? 8
+            : 0
+        ),
+        color: band.map((_, index) =>
+          selectedPoint?.x === distances[index] &&
+          selectedPoint?.y === band[index]
+            ? "black"
+            : hoveredPoint?.x === distances[index] &&
+              hoveredPoint?.y === band[index]
+            ? "lightblue"
+            : "transparent"
+        ),
+      },
+      opacity: 1,
+    },
+  }));
 };
 
 const getLayout = (

--- a/src/components/BandsView.tsx
+++ b/src/components/BandsView.tsx
@@ -6,49 +6,6 @@ import { PlotDatum, PlotMouseEvent } from "plotly.js";
 
 import { HighSymPoint } from "./types";
 
-const getLayout = (
-  highSymPoints: HighSymPoint[],
-  distances: number[],
-  eigenvalues: number[][]
-) => ({
-  showlegend: false,
-  hovermode: "closest",
-  xaxis: {
-    linewidth: 0,
-    linecolor: "transparent",
-    tickvals: highSymPoints.map(([index]) => distances[index]),
-    ticktext: highSymPoints.map(([, label]) => label),
-    range: [Math.min(...distances.flat()), Math.max(...distances.flat())],
-  },
-  yaxis: {
-    title: "Frequency (cm-1)",
-    linewidth: 0,
-    linecolor: "transparent",
-    ticklen: 5,
-    range: [Math.min(...eigenvalues.flat()), Math.max(...eigenvalues.flat())],
-  },
-  // vertical lines at high-symmetry points
-  shapes: highSymPoints.map(([index]) => ({
-    type: "line",
-    yref: "paper",
-    x0: distances[index],
-    y0: 0,
-    x1: distances[index],
-    y1: 1,
-    line: {
-      width: 0.5,
-    },
-  })),
-  dragmode: "zoom",
-  autosize: true,
-  margin: {
-    l: 55,
-    r: 10,
-    b: 25,
-    t: 40,
-  },
-});
-
 const getPlotData = (
   bands: number[][],
   distances: number[],
@@ -177,6 +134,49 @@ const BandsView = ({
     </Card>
   );
 };
+
+const getLayout = (
+  highSymPoints: HighSymPoint[],
+  distances: number[],
+  eigenvalues: number[][]
+) => ({
+  showlegend: false,
+  hovermode: "closest",
+  xaxis: {
+    linewidth: 0,
+    linecolor: "transparent",
+    tickvals: highSymPoints.map(([index]) => distances[index]),
+    ticktext: highSymPoints.map(([, label]) => label),
+    range: [Math.min(...distances.flat()), Math.max(...distances.flat())],
+  },
+  yaxis: {
+    title: "Frequency (cm-1)",
+    linewidth: 0,
+    linecolor: "transparent",
+    ticklen: 5,
+    range: [Math.min(...eigenvalues.flat()), Math.max(...eigenvalues.flat())],
+  },
+  // vertical lines at high-symmetry points
+  shapes: highSymPoints.map(([index]) => ({
+    type: "line",
+    yref: "paper",
+    x0: distances[index],
+    y0: 0,
+    x1: distances[index],
+    y1: 1,
+    line: {
+      width: 0.5,
+    },
+  })),
+  dragmode: "zoom",
+  autosize: true,
+  margin: {
+    l: 55,
+    r: 10,
+    b: 25,
+    t: 40,
+  },
+});
 
 const MemoizedBandsView = memo(BandsView);
 

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -142,13 +142,28 @@ const ControlsPanel = () => {
               <Form.Label>Camera</Form.Label>
             </Col>
             <Col>
-              <Button size="sm" variant="secondary" value="x" onClick={updateCamera}>
+              <Button
+                size="sm"
+                variant="secondary"
+                value="x"
+                onClick={updateCamera}
+              >
                 X
               </Button>
-              <Button size="sm" variant="secondary" value="y" onClick={updateCamera}>
+              <Button
+                size="sm"
+                variant="secondary"
+                value="y"
+                onClick={updateCamera}
+              >
                 Y
               </Button>
-              <Button size="sm" variant="secondary" value="z" onClick={updateCamera}>
+              <Button
+                size="sm"
+                variant="secondary"
+                value="z"
+                onClick={updateCamera}
+              >
                 Z
               </Button>
             </Col>
@@ -197,7 +212,7 @@ const ControlsPanel = () => {
             <Col xs="8">
               <Form.Range
                 min="1"
-                max="5"
+                max="4"
                 step="0.1"
                 defaultValue={vectorLength}
                 onChange={updateVectors}

--- a/src/components/useParameters.ts
+++ b/src/components/useParameters.ts
@@ -7,8 +7,8 @@ const useParameters = (repetitions: number[]) => {
   const [nz, setNz] = useState(Nz);
   const [cameraDirection, setCameraDirection] = useState([0, 0, 1]);
   const [showCell, setShowCell] = useState(true);
-  const [amplitude, setAmplitude] = useState(0.30);
-  const [vectorLength, setVectorLength] = useState(3.5);
+  const [amplitude, setAmplitude] = useState(0.3);
+  const [vectorLength, setVectorLength] = useState(1.5);
   const [showVectors, setShowVectors] = useState(true);
   const [speed, setSpeed] = useState(0.25);
 


### PR DESCRIPTION
fixes #5 

Currently, the whole `<Plot />` object is remade when state changes (e.g. by hovering over a band), resetting any state reached by user interaction (zoom/pan).

These changes should fix this issue. I'm storing different parts of the  `<Plot />`  props in state and updating only what's necessary.

I think what's also relevant here is https://github.com/plotly/react-plotly.js?tab=readme-ov-file#state-management

Basically, `<Plot />` modifies its props internally, which goes against the rules of react (e.g. i think layout is changed when user zooms). Currently i made this such that, this variable will be in the state of `BandsView` and as long as we don't remake this whole thing, the interally-updated layout is retained, even if other parts of the props are changed (e.g. the data).

I think in the future we can reconsider this and think what's the definitively correct way to handle this (maybe even by dropping react-plotly as it seems a bit inactive and has old issues that nobody is working on).