### PR TITLE
Cell view overlay update; play button styling

### DIFF
--- a/src/components/CellView.scss
+++ b/src/components/CellView.scss
@@ -4,7 +4,7 @@
   position: absolute;
   left: 0;
   top: 40px;
-  height: calc(100% - 40px);
+  height: calc(100% - 80px);
   width: 100%;
   cursor: pointer;
   background-color: rgba(0, 0, 0, 0.025);
@@ -22,4 +22,41 @@
     font-weight: 600;
     color: rgb(80, 80, 80);
   }
+}
+
+.weas-container {
+  overflow: hidden;
+  padding: 0;
+}
+
+.disable-mouse {
+  pointer-events: none;
+}
+
+.mouse-interact-note {
+  background-color: #f8f8f8;
+  border: 1px solid #999999;
+  color: #353434;
+  padding: 1px 6px;
+  border-radius: 5px;
+  position: absolute;
+  bottom: 15px;
+  right: 20px;
+  z-index: 3;
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    filter: brightness(90%);
+  }
+}
+
+.off {
+  display: none;
+}
+
+.play-button {
+  position: absolute;
+  bottom: 15px;
+  left: 20px;
 }

--- a/src/components/CellView.tsx
+++ b/src/components/CellView.tsx
@@ -26,43 +26,6 @@ const defaultGuiConfig = {
   },
 };
 
-const InteractionGuard = ({ children }: { children: React.ReactNode }) => {
-  const [isInteractive, setIsInteractive] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement | null>(null);
-
-  let mouseNoteClass = "mouse-interact-note";
-  if (isInteractive) {
-    mouseNoteClass += " off";
-  }
-
-  let guardClassName = "";
-  if (!isInteractive) guardClassName += " disable-mouse";
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(event.target as Node)
-      ) {
-        setIsInteractive(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
-
-  return (
-    <div ref={wrapperRef} onClick={() => setIsInteractive(true)}>
-      <div className={guardClassName}>{children}</div>
-      <div className={mouseNoteClass} onClick={() => setIsInteractive(true)}>
-        Click to interact
-      </div>
-    </div>
-  );
-};
-
 const CellView = ({
   props,
   mode,
@@ -182,6 +145,43 @@ const CellView = ({
         </Button>
       </Card.Body>
     </Card>
+  );
+};
+
+const InteractionGuard = ({ children }: { children: React.ReactNode }) => {
+  const [isInteractive, setIsInteractive] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  let mouseNoteClass = "mouse-interact-note";
+  if (isInteractive) {
+    mouseNoteClass += " off";
+  }
+
+  let guardClassName = "";
+  if (!isInteractive) guardClassName += " disable-mouse";
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(event.target as Node)
+      ) {
+        setIsInteractive(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div ref={wrapperRef} onClick={() => setIsInteractive(true)}>
+      <div className={guardClassName}>{children}</div>
+      <div className={mouseNoteClass} onClick={() => setIsInteractive(true)}>
+        Click to interact
+      </div>
+    </div>
   );
 };
 

--- a/src/components/CellView.tsx
+++ b/src/components/CellView.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
-import { Card } from "react-bootstrap";
+import { useContext, useEffect, useRef, useState } from "react";
+import { Card, Button } from "react-bootstrap";
 
 import { Atoms, WEAS } from "weas";
 
@@ -11,10 +11,10 @@ import "./CellView.scss";
 const defaultGuiConfig = {
   controls: {
     enabled: false,
-    atomsControl: true,
-    colorControl: true,
+    atomsControl: false,
+    colorControl: false,
     cameraControls: false,
-    buttons: true,
+    buttons: false,
   },
   buttons: {
     enabled: false,
@@ -26,6 +26,43 @@ const defaultGuiConfig = {
   },
 };
 
+const InteractionGuard = ({ children }: { children: React.ReactNode }) => {
+  const [isInteractive, setIsInteractive] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  let mouseNoteClass = "mouse-interact-note";
+  if (isInteractive) {
+    mouseNoteClass += " off";
+  }
+
+  let guardClassName = "";
+  if (!isInteractive) guardClassName += " disable-mouse";
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(event.target as Node)
+      ) {
+        setIsInteractive(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div ref={wrapperRef} onClick={() => setIsInteractive(true)}>
+      <div className={guardClassName}>{children}</div>
+      <div className={mouseNoteClass} onClick={() => setIsInteractive(true)}>
+        Click to interact
+      </div>
+    </div>
+  );
+};
+
 const CellView = ({
   props,
   mode,
@@ -33,7 +70,7 @@ const CellView = ({
   props: VisualizerProps;
   mode: number[];
 }) => {
-  const [isInteractive, setIsInteractive] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
   const viewerRef = useRef<HTMLDivElement | null>(null);
   const weasRef = useRef<WEAS | null>(null);
   const {
@@ -48,19 +85,6 @@ const CellView = ({
     speed,
     // isAnimated,
   } = useContext(ParametersContext);
-
-  const toggleOverlay = useCallback(() => {
-    setIsInteractive((prevState) => !prevState);
-  }, []);
-
-  const Overlay = () => (
-    <div className="overlay-div">
-      <span>
-        Double-click to toggle interactions on and off <br />{" "}
-        <small>(This feature is not available on iPad and iPhone)</small>
-      </span>
-    </div>
-  );
 
   useEffect(() => {
     const [q, e] = mode;
@@ -126,12 +150,36 @@ const CellView = ({
     vectorLength,
   ]);
 
+  const togglePlay = () => {
+    if (weasRef.current) {
+      if (weasRef.current.avr.isPlaying) {
+        weasRef.current.avr.pause();
+        setIsPlaying(false);
+      } else {
+        weasRef.current.avr.play();
+        setIsPlaying(true);
+      }
+    }
+  };
+
   return (
     <Card>
       <Card.Header>Drag to rotate, scroll to zoom</Card.Header>
-      <Card.Body onDoubleClick={toggleOverlay} style={{paddingBottom: "40px"}}>
-        {!isInteractive && <Overlay />}
-        <div ref={viewerRef} style={{ width: "100%", height: "450px" }}></div>
+      <Card.Body className="p-0">
+        <InteractionGuard>
+          <div
+            className="weas-container"
+            ref={viewerRef}
+            style={{ width: "100%", height: "450px" }}
+          ></div>
+        </InteractionGuard>
+        <Button className="play-button" size="sm" onClick={togglePlay}>
+          {isPlaying ? (
+            <i className="bi bi-pause-fill"></i>
+          ) : (
+            <i className="bi bi-play-fill"></i>
+          )}
+        </Button>
       </Card.Body>
     </Card>
   );


### PR DESCRIPTION
fixes #8 by just hiding the weas animation control buttons and making a new one.

Additionally, the same mouse interaction overlay was adapted from `mc-react-structure-visualizer`

also fixes #7